### PR TITLE
Fail when nomad_server and nomad_client both set

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
 # tasks file for nomad
 
+- name: Check if both nomad_server and nomad_client set
+  fail: msg='nomad_server and nomad_client were both set. According to https://nomadproject.io/docs/agent/config.html, "Note that it is strongly recommended not to operate a node as both client and server".'
+  when: nomad_server and nomad_client
+
 - name: Include distribution specific variables
   include_vars: "{{ ansible_distribution }}.yml"
   tags: nomad


### PR DESCRIPTION
and emit a helpful error message.

According to https://nomadproject.io/docs/agent/config.html, "Note that
it is strongly recommended not to operate a node as both client and
server".

Without this, someone can easily set `nomad_server` to true, not
realizing that `nomad_client` is set to true by default, and the result
of this is that the playbook runs successfully but no process is started
on the target node because it ends up with an upstart config that has no
script to run in it. This is a bit confusing.

Fixes: GH-5

Tested with this playbook:

``` yaml
- hosts: devops
  vars:
    nomad_server: true
    nomad_client: true
  roles:
    - nomad
```

I tested as follows:

```
$ ansible-playbook playbook.yml --sudo
...
TASK: [nomad | Check if both nomad_server and nomad_client set] ***************
failed: [devops] => {"failed": true}
msg: nomad_server and nomad_client were both set. According to https://nomadproject.io/docs/agent/config.html, "Note that it is strongly recommended not to operate a node as both client and server".

FATAL: all hosts have already failed -- aborting
...
```
