### PR TITLE
Fix Nomad networks initialization

### DIFF
--- a/templates/nomad.conf.j2
+++ b/templates/nomad.conf.j2
@@ -3,8 +3,9 @@
 description "Service for nomad"
 author "Kevin Brebanov"
 
-start on filesystem or runlevel [2345]
-stop on shutdown
+start on (local-filesystems and net-device-up IFACE!=lo)
+
+stop on runlevel [!2345]
 
 reload signal SIGHUP
 


### PR DESCRIPTION
When nomad starts just on `runlevel` then it doesn't always initialize node networks right.
If I try to run some Nomad job then I will receive following error in this case: 
```
   * Resources exhausted on 1 nodes
   * Dimension "network: bandwidth exceeded" exhausted on 1 nodes
```
Through REST API it also shows `Networks: null`. It is because Nomad started before any non-loopback network is available. If restart Nomad service then it starts work.

Provided fix adds checking for network availability before Nomad agent start.
